### PR TITLE
TASK: Define typo3-cms/extension-key composer setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "post-update-cmd": "Tooly\\ScriptHandler::installPharTools"
   },
   "extra": {
+    "typo3/cms": {
+      "extension-key": "me_backend_security"
+    },
     "tools": {
       "phpunit": {
         "url": "https://phar.phpunit.de/phpunit-8.0.1.phar",


### PR DESCRIPTION
Specifying the extension key will be mandatory in future
versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)