### PR TITLE
[FIX] Fix password reset when the user have a MFA activated

### DIFF
--- a/Classes/Authentication/BackendUserAuthentication.php
+++ b/Classes/Authentication/BackendUserAuthentication.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MoveElevator\MeBackendSecurity\Authentication;
+
+use MoveElevator\MeBackendSecurity\Utility\MfaUtility;
+use TYPO3\CMS\Core\Authentication\Mfa\MfaRequiredException;
+use TYPO3\CMS\Core\Http\ServerRequestFactory;
+
+class BackendUserAuthentication extends \TYPO3\CMS\Core\Authentication\BackendUserAuthentication {
+
+    protected function evaluateMfaRequirements(): void
+    {
+        try {
+            parent::evaluateMfaRequirements();
+        } catch (MfaRequiredException $mfaRequiredException) {
+            $request = $GLOBALS['TYPO3_REQUEST'] ?? ServerRequestFactory::fromGlobals();
+            $token = $request->getParsedBody()['tx_mebackendsecurity']['mfaToken'] ?? null;
+            if ($token !== MfaUtility::getMfaToken($this)) {
+                throw $mfaRequiredException;
+            }
+        }
+    }
+}

--- a/Classes/Factory/LoginProviderRedirectFactory.php
+++ b/Classes/Factory/LoginProviderRedirectFactory.php
@@ -13,6 +13,7 @@ class LoginProviderRedirectFactory
     public static function create(
         string $username = '',
         array $errors = [],
+        string $mfaToken = '',
         array $messages = []
     ): LoginProviderRedirect {
         $parameter = [
@@ -29,6 +30,10 @@ class LoginProviderRedirectFactory
 
         if (empty($messages) === false) {
             $parameter['m'] = urlencode(base64_encode(serialize($messages)));
+        }
+
+        if (empty($mfaToken) === false) {
+            $parameter['x'] = urlencode(base64_encode(serialize($mfaToken)));
         }
 
         $loginProviderRedirect = new LoginProviderRedirect();

--- a/Classes/LoginProvider/UsernamePasswordLoginProvider.php
+++ b/Classes/LoginProvider/UsernamePasswordLoginProvider.php
@@ -78,6 +78,15 @@ class UsernamePasswordLoginProvider extends \TYPO3\CMS\Backend\LoginProvider\Use
             );
         }
 
+        $x = GeneralUtility::_GP('x');
+
+        if (empty($x) === false) {
+            $view->assign(
+                'mfaToken',
+                unserialize(base64_decode(urldecode($x)), ['allowed_classes' => false])
+            );
+        }
+
         $pageRenderer->loadRequireJsModule(
             'TYPO3/CMS/MeBackendSecurity/PasswordValidator'
         );

--- a/Classes/Utility/MfaUtility.php
+++ b/Classes/Utility/MfaUtility.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoveElevator\MeBackendSecurity\Utility;
+
+use DateInterval;
+use DateTime;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class MfaUtility
+{
+    public static function getMfaToken(BackendUserAuthentication $user): string
+    {
+        $hash = GeneralUtility::hmac((string)$user->user['tx_mebackendsecurity_lastpasswordchange'] . '|'
+            . $user->user['mfa'] . '|'
+            . $user->user['email'] . '|'
+            . (string)$user->user['uid'], 'mfa-token');
+        return $hash;
+    }
+}

--- a/Resources/Private/Templates/LoginProvider/PasswordResetLoginForm.html
+++ b/Resources/Private/Templates/LoginProvider/PasswordResetLoginForm.html
@@ -108,6 +108,9 @@
 		</div>
 	</div>
 	<f:if condition="{presetUsername}">
+        <input type="hidden"
+               name="tx_mebackendsecurity[mfaToken]"
+               value="{mfaToken}"/>
 		<div class="form-group">
 			<div class="form-control-wrap">
 				<div class="form-control-holder">

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,12 +3,14 @@
 defined('TYPO3') || die();
 
 use MoveElevator\MeBackendSecurity\Authentication\PasswordReset;
+use MoveElevator\MeBackendSecurity\Authentication\BackendUserAuthentication;
 use MoveElevator\MeBackendSecurity\Controller\ResetPasswordController;
 use MoveElevator\MeBackendSecurity\Evaluation\PasswordEvaluator;
 use MoveElevator\MeBackendSecurity\Hook\BackendUserTableHook;
 use MoveElevator\MeBackendSecurity\Hook\UserAuthHook;
 use MoveElevator\MeBackendSecurity\LoginProvider\UsernamePasswordLoginProvider;
 use TYPO3\CMS\Backend\Authentication\PasswordReset as CorePasswordReset;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication as CoreBackendUserAuthentication;
 use TYPO3\CMS\Backend\Controller\ResetPasswordController as CoreResetPasswordController;
 
 (static function () {
@@ -30,5 +32,9 @@ use TYPO3\CMS\Backend\Controller\ResetPasswordController as CoreResetPasswordCon
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][CoreResetPasswordController::class] = [
         'className' => ResetPasswordController::class,
+    ];
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][CoreBackendUserAuthentication::class] = [
+        'className' => BackendUserAuthentication::class
     ];
 })();


### PR DESCRIPTION
Since the extension use the same process as the login to reset the expired password, we are not considered logged in even after the initial MFA prompt. This cause a loop where we are asked indefinitely the MFA confirmation.

I added a token when we confirmed the MFA that is injected in the form to change the password. I XClassed the BackendUserAuthentication to add a check to see if the token is valid for the user. If it is, then the MFA check is bypass and we can continue with the process.